### PR TITLE
Added support for the latest gradle version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,9 +28,9 @@ dependencies {
 }
 
 task fatJar(type: Jar) {
-    baseName = 'CORE-FAT'
+    archiveBaseName = 'CORE-FAT'
     from {
-        configurations.compile.collect {
+        configurations.runtimeClasspath.collect {
             it.isDirectory() ? it : zipTree(it)
         }
     }
@@ -39,5 +39,6 @@ task fatJar(type: Jar) {
                 'Main-Class': 'edu.puc.core.Main'
         )
     }
+    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
     with jar
 }


### PR DESCRIPTION
Previously the build instructions did not work with the latest gradle version and was using deprecated names in the build.gradle file. Now with these simple changes new gradle versions support the projects compilation.